### PR TITLE
Enhancements in secure-roks cluster example

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: go test -v ./...
         env:
           IC_API_KEY: ${{ secrets.ACCESS_KEY }}
-          
+
       - uses: 8398a7/action-slack@v2
         with:
           status: ${{ job.status }}

--- a/.github/workflows/validate_terraform.yml
+++ b/.github/workflows/validate_terraform.yml
@@ -37,7 +37,7 @@ jobs:
       -
         name: terraform fmt check           # perform format checks
         run: terraform fmt -list=true -write=false -check -recursive
-        
+
       - uses: 8398a7/action-slack@v2
         with:
           status: ${{ job.status }}

--- a/examples/secure-roks-cluster/activity-tracker.tf
+++ b/examples/secure-roks-cluster/activity-tracker.tf
@@ -1,16 +1,9 @@
 resource "ibm_resource_instance" "activity_tracker_instance" {
-  count             = var.activity_tracker_instance_name != null ? 0 : 1
+  count             = var.activity_tracker_instance != null ? 0 : 1
   name              = "${var.resource_prefix}-at"
   location          = var.region
   resource_group_id = data.ibm_resource_group.resource_group.id
   service           = "logdnaat"
   plan              = "lite"
-  tags              = ["secure-roks"]
-}
-data "ibm_resource_instance" "activity_tracker_instance" {
-  count             = var.activity_tracker_instance_name != null ? 1 : 0
-  name              = var.activity_tracker_instance_name
-  service           = "logdnaat"
-  resource_group_id = data.ibm_resource_group.resource_group.id
-  location          = var.region
+  tags              = ["secure-roks", var.resource_prefix]
 }

--- a/examples/secure-roks-cluster/cos.tf
+++ b/examples/secure-roks-cluster/cos.tf
@@ -12,5 +12,5 @@ resource "ibm_resource_instance" "cos_instance" {
   resource_group_id = data.ibm_resource_group.resource_group.id
   service           = "cloud-object-storage"
   plan              = "standard"
-  tags              = ["secure-roks"]
+  tags              = ["secure-roks", var.resource_prefix]
 }

--- a/examples/secure-roks-cluster/kms.tf
+++ b/examples/secure-roks-cluster/kms.tf
@@ -1,15 +1,3 @@
-data "ibm_resource_instance" "kms_instance" {
-  count             = var.kms_instance != null ? 1 : 0
-  name              = var.kms_instance
-  service           = "kms"
-  resource_group_id = data.ibm_resource_group.resource_group.id
-  location          = var.region
-}
-data "ibm_kms_key" "kms_key" {
-  count       = var.kms_instance != null && var.kms_key != null ? 1 : 0
-  instance_id = data.ibm_resource_instance.kms_instance[0].guid
-  key_name    = var.kms_key
-}
 module "kms" {
   count                = var.kms_instance == null && var.kms_key == null ? 1 : 0
   source               = "terraform-ibm-modules/kms/ibm//modules/key-protect"
@@ -18,7 +6,7 @@ module "kms" {
   service_name         = "${var.resource_prefix}-kp"
   location             = var.region
   plan                 = "tiered-pricing"
-  tags                 = ["secure-roks"]
+  tags                 = ["secure-roks", var.resource_prefix]
   key_name             = "${var.resource_prefix}-kp-key"
   standard_key_type    = var.standard_key_type
 }

--- a/examples/secure-roks-cluster/locals.tf
+++ b/examples/secure-roks-cluster/locals.tf
@@ -1,22 +1,17 @@
 locals {
   cos_crn            = var.cos_instance_name != null ? data.ibm_resource_instance.cos_instance[0].id : ibm_resource_instance.cos_instance[0].id
-  sysdig_instance_id = var.logdna_name != null ? data.ibm_resource_instance.sysdig_instance[0].guid : module.sysdig_instance[0].sysdig_guid
-  logdna_instance_id = var.logdna_name != null ? data.ibm_resource_instance.logdna_instance[0].guid : module.logdna_instance[0].logdna_instance_guid
+  sysdig_instance_id = var.sysdig_instance != null ? var.sysdig_instance : module.sysdig_instance[0].sysdig_guid
+  logdna_instance_id = var.logdna_instance != null ? var.logdna_instance : module.logdna_instance[0].logdna_instance_guid
   zones              = [for index in range(3) : "${var.region}-${index + 1}"]
   worker_zones = {
-    element(local.zones, 0) = {
-      subnet_id = module.subnet[local.zones[0]].subnet_id
-    }
-  }
-  pool_worker_zones = {
-    for zone in slice(local.zones, 1, 3) :
+    for zone in local.zones :
     zone => {
       subnet_id = module.subnet[zone].subnet_id
     }
   }
   kms_config = var.kms_instance != null && var.kms_key != null ? [{
-    instance_id      = data.ibm_resource_instance.kms_instance[0].guid
-    crk_id           = data.ibm_kms_key.kms_key[0].keys[0].id
+    instance_id      = var.kms_instance
+    crk_id           = var.kms_key
     private_endpoint = true
     }] : [{
     instance_id      = module.kms[0].kms_instance_guid
@@ -26,6 +21,65 @@ locals {
   timeouts = [{
     create = var.create_timeout
   }]
+  sg_rules = [
+    for r in local.rules : {
+      name       = r.name
+      direction  = r.direction
+      remote     = lookup(r, "remote", null)
+      ip_version = lookup(r, "ip_version", null)
+      icmp       = lookup(r, "icmp", null)
+      tcp        = lookup(r, "tcp", null)
+      udp        = lookup(r, "udp", null)
+    }
+  ]
+  rules = [
+    {
+      name      = "${var.resource_prefix}-ingress-1"
+      direction = "inbound"
+      tcp = {
+        port_min = 22
+        port_max = 22
+      }
+    },
+    {
+      name      = "${var.resource_prefix}-ingress-2"
+      direction = "inbound"
+      icmp = {
+        type = 8
+        code = null
+      }
+    },
+    {
+      name      = "${var.resource_prefix}-egress-1"
+      direction = "outbound"
+      remote    = module.vpc.vpc_default_security_group
+    },
+    {
+      name      = "${var.resource_prefix}-egress-2"
+      direction = "outbound"
+      remote    = "161.26.0.0/16"
+    },
+    {
+      name      = "${var.resource_prefix}-egress-3"
+      direction = "outbound"
+      remote    = "166.8.0.0/14"
+    },
+    {
+      name      = "${var.resource_prefix}-egress-4"
+      direction = "outbound"
+      remote    = local.subnet_cidrs[0]
+    },
+    {
+      name      = "${var.resource_prefix}-egress-5"
+      direction = "outbound"
+      remote    = local.subnet_cidrs[1]
+    },
+    {
+      name      = "${var.resource_prefix}-egress-6"
+      direction = "outbound"
+      remote    = local.subnet_cidrs[2]
+    }
+  ]
   custom_sg_rules = [
     for r in var.custom_sg_rules : {
       name       = r.name
@@ -37,4 +91,9 @@ locals {
       udp        = lookup(r, "udp", null)
     }
   ]
+  default_egress_rule = [
+    for _, rule in data.ibm_is_vpc.vpc.security_group[0].rules : rule.rule_id
+    if rule.remote == "0.0.0.0/0" && rule.direction == "outbound" && rule.protocol == "all"
+  ]
+  subnet_cidrs = [for subnet in data.ibm_is_subnet.subnet : subnet.ipv4_cidr_block]
 }

--- a/examples/secure-roks-cluster/logging.tf
+++ b/examples/secure-roks-cluster/logging.tf
@@ -1,25 +1,18 @@
 module "logdna_instance" {
   source = "terraform-ibm-modules/observability/ibm//modules/logging-logdna"
 
-  count             = var.logdna_name == null ? 1 : 0
+  count             = var.logdna_instance == null ? 1 : 0
   bind_resource_key = true
   service_name      = "${var.resource_prefix}-logdna"
   resource_group_id = data.ibm_resource_group.resource_group.id
   plan              = "lite"
   region            = var.region
-  tags              = ["secure-roks"]
+  tags              = ["secure-roks", var.resource_prefix]
   create_timeout    = "30m"
   resource_key_name = "${var.resource_prefix}-logdna-key"
   role              = "Manager"
-  resource_key_tags = ["secure-roks"]
+  resource_key_tags = ["secure-roks", var.resource_prefix]
   parameters = {
     default_receiver = true #enable for platform metrics
   }
-}
-data "ibm_resource_instance" "logdna_instance" {
-  count             = var.logdna_name != null ? 1 : 0
-  name              = var.logdna_name
-  service           = "logdna"
-  resource_group_id = data.ibm_resource_group.resource_group.id
-  location          = var.region
 }

--- a/examples/secure-roks-cluster/main.tf
+++ b/examples/secure-roks-cluster/main.tf
@@ -4,8 +4,11 @@ data "ibm_resource_group" "resource_group" {
 }
 
 module "vpc_ocp_cluster" {
-  source = "terraform-ibm-modules/cluster/ibm//modules/vpc-openshift"
-
+  source  = "terraform-ibm-modules/cluster/ibm//modules/vpc-openshift"
+  version = "1.4.0"
+  depends_on = [
+    null_resource.delete_default_egress_security_rule
+  ]
   cluster_name                    = "${var.resource_prefix}-cluster"
   vpc_id                          = module.vpc.vpc_id
   worker_pool_flavor              = var.flavor
@@ -13,36 +16,27 @@ module "vpc_ocp_cluster" {
   kube_version                    = var.ocp_version
   worker_zones                    = local.worker_zones
   worker_nodes_per_zone           = var.worker_nodes_per_zone
-  tags                            = ["secure-roks", "cluster"]
+  tags                            = ["secure-roks", "cluster", var.resource_prefix]
   disable_public_service_endpoint = var.disable_public_service_endpoint
   entitlement                     = var.ocp_entitlement
   cos_instance_crn                = local.cos_crn
   kms_config                      = local.kms_config
+  worker_labels                   = { worker = var.resource_prefix }
+  create_timeout                  = var.create_timeout
 }
-module "vpc_ocp_cluster_worker_pool" {
-  source = "terraform-ibm-modules/cluster/ibm//modules/configure-vpc-worker-pool"
 
-  cluster_name          = module.vpc_ocp_cluster.vpc_openshift_cluster_id
-  worker_pool_name      = "${var.resource_prefix}-worker-pool"
-  worker_nodes_per_zone = var.worker_nodes_per_zone
-  flavor                = var.flavor
-  resource_group_id     = data.ibm_resource_group.resource_group.id
-  virtual_private_cloud = module.vpc.vpc_id
-  worker_zones          = local.pool_worker_zones
-  labels                = { worker-pool = var.resource_prefix }
-  entitlement           = var.ocp_entitlement
-}
 module "configure_cluster_sysdig" {
-  source = "terraform-ibm-modules/cluster/ibm//modules/configure-sysdig-monitor"
-
+  source             = "terraform-ibm-modules/cluster/ibm//modules/configure-sysdig-monitor"
+  version            = "1.4.0"
   cluster            = module.vpc_ocp_cluster.vpc_openshift_cluster_id
   sysdig_instance_id = local.sysdig_instance_id
   private_endpoint   = var.private_endpoint
   sysdig_access_key  = var.sysdig_access_key
 }
 module "configure_cluster_logdna" {
-  source = "terraform-ibm-modules/cluster/ibm//modules/configure-logdna"
-
+  source               = "terraform-ibm-modules/cluster/ibm//modules/configure-logdna"
+  version              = "1.4.0"
+  depends_on           = [module.configure_cluster_sysdig]
   cluster              = module.vpc_ocp_cluster.vpc_openshift_cluster_id
   logdna_instance_id   = local.logdna_instance_id
   private_endpoint     = var.private_endpoint

--- a/examples/secure-roks-cluster/monitoring.tf
+++ b/examples/secure-roks-cluster/monitoring.tf
@@ -1,25 +1,18 @@
 module "sysdig_instance" {
   source = "terraform-ibm-modules/observability/ibm//modules/monitoring-sysdig"
 
-  count             = var.sysdig_name == null ? 1 : 0
+  count             = var.sysdig_instance == null ? 1 : 0
   bind_resource_key = true
   service_name      = "${var.resource_prefix}-sysdig"
   resource_group_id = data.ibm_resource_group.resource_group.id
   plan              = "lite"
   region            = var.region
-  tags              = ["secure-roks"]
+  tags              = ["secure-roks", var.resource_prefix]
   create_timeout    = "30m"
   resource_key_name = "${var.resource_prefix}-sysdig-key"
   role              = "Manager"
-  resource_key_tags = ["secure-roks"]
+  resource_key_tags = ["secure-roks", var.resource_prefix]
   parameters = {
     default_receiver = true #enable for platform metrics
   }
-}
-data "ibm_resource_instance" "sysdig_instance" {
-  count             = var.sysdig_name != null ? 1 : 0
-  name              = var.sysdig_name
-  service           = "sysdig-monitor"
-  resource_group_id = data.ibm_resource_group.resource_group.id
-  location          = var.region
 }

--- a/examples/secure-roks-cluster/network.tf
+++ b/examples/secure-roks-cluster/network.tf
@@ -4,19 +4,56 @@ module "vpc" {
 
   name              = "${var.resource_prefix}-vpc"
   resource_group_id = data.ibm_resource_group.resource_group.id
+  tags              = ["secure-roks", var.resource_prefix]
 }
 module "subnet" {
   source  = "terraform-ibm-modules/vpc/ibm//modules/subnet"
   version = "1.0.0"
 
-  for_each          = toset(local.zones)
-  name              = "${var.resource_prefix}-subnet-${index(local.zones, each.value)}"
-  vpc_id            = module.vpc.vpc_id
-  resource_group_id = data.ibm_resource_group.resource_group.id
-  location          = each.value
-  ip_range          = element(var.ip_ranges, index(local.zones, each.value))
+  for_each            = toset(local.zones)
+  name                = "${var.resource_prefix}-subnet-${index(local.zones, each.value)}"
+  vpc_id              = module.vpc.vpc_id
+  resource_group_id   = data.ibm_resource_group.resource_group.id
+  location            = each.value
+  ip_range            = (var.number_of_addresses == null && var.ip_ranges != null ? element(var.ip_ranges, index(local.zones, each.value)) : null)
+  number_of_addresses = (var.number_of_addresses != null && var.ip_ranges == null ? var.number_of_addresses : null)
 }
 
+data "ibm_is_subnet" "subnet" {
+  depends_on = [module.subnet]
+  for_each   = toset(local.zones)
+  name       = "${var.resource_prefix}-subnet-${index(local.zones, each.value)}"
+}
+
+module "default_sg_rules" {
+  source  = "terraform-ibm-modules/vpc/ibm//modules/security-group"
+  version = "1.0.0"
+
+  create_security_group = false
+  security_group        = module.vpc.vpc_default_security_group
+  resource_group_id     = data.ibm_resource_group.resource_group.id
+  security_group_rules  = local.sg_rules
+}
+data "ibm_is_vpc" "vpc" {
+  depends_on = [module.vpc]
+  name       = "${var.resource_prefix}-vpc"
+}
+data "ibm_iam_auth_token" "token" {}
+
+// null resource to remove allow all outbound rule
+resource "null_resource" "delete_default_egress_security_rule" {
+  provisioner "local-exec" {
+    environment = {
+      TOKEN               = data.ibm_iam_auth_token.token.iam_access_token
+      REGION              = var.region
+      SECURITY_GROUP      = module.vpc.vpc_default_security_group
+      SECURITY_GROUP_RULE = length(local.default_egress_rule) != 0 ? local.default_egress_rule[0] : ""
+    }
+    command = <<EOT
+          curl -X DELETE "https://$REGION.iaas.cloud.ibm.com/v1/security_groups/$SECURITY_GROUP/rules/$SECURITY_GROUP_RULE?version=2021-08-03&generation=2" -H "Authorization: $TOKEN"
+        EOT
+  }
+}
 module "custom_sg_rules" {
   source  = "terraform-ibm-modules/vpc/ibm//modules/security-group"
   version = "1.0.0"

--- a/examples/secure-roks-cluster/variables.tf
+++ b/examples/secure-roks-cluster/variables.tf
@@ -40,7 +40,7 @@ variable "flavor" {
 variable "ocp_version" {
   type        = string
   description = "Specify the Openshift version"
-  default     = "4.6.23_1540_openshift"
+  default     = "4.6_openshift"
 }
 variable "ocp_entitlement" {
   type        = string
@@ -60,7 +60,7 @@ variable "worker_nodes_per_zone" {
 variable "create_timeout" {
   type        = string
   description = "Custom Creation timeout for Cluster"
-  default     = null
+  default     = "3h"
 }
 
 ######################################################
@@ -76,12 +76,12 @@ variable "roks_kms_policy" {
 #IBM-Cloud Key Protect Variables
 ######################################################
 variable "kms_instance" {
-  description = "Name of Key Protect Instance. If null it creates an instance with `<var.resource_prefix>-kp`"
+  description = "GUID of Key Protect Instance. If null it creates an instance with name `<var.resource_prefix>-kp`"
   type        = string
   default     = null
 }
 variable "kms_key" {
-  description = "Name of Key Protect Key. If null it creates an instance with `<var.resource_prefix>-kp-key`"
+  description = "Key ID of Key Protect Key. If null it creates an instance with name `<var.resource_prefix>-kp-key`"
   type        = string
   default     = null
 }
@@ -94,20 +94,20 @@ variable "standard_key_type" {
 ######################################################
 #IBM-Cloud Logging and Monitoring Variables
 ######################################################
-variable "sysdig_name" {
+variable "sysdig_instance" {
   default     = null
   type        = string
-  description = "Name of Sysdig Instance. If null it creates an instance with `<var.resource_prefix>-sysdig`"
+  description = "GUID of Sysdig Instance. If null it creates an instance with name `<var.resource_prefix>-sysdig`"
 }
 variable "sysdig_access_key" {
   description = "The sysdig monitoring ingestion key that you want to use for your configuration"
   type        = string
   default     = null
 }
-variable "logdna_name" {
+variable "logdna_instance" {
   default     = null
   type        = string
-  description = "Name of logdna_name Instance. If null it creates an instance with `<var.resource_prefix>-logdna`"
+  description = "GUID of Logging Instance. If null it creates an instance with `<var.resource_prefix>-logdna`"
 }
 variable "logdna_ingestion_key" {
   description = "The LogDNA ingestion key that you want to use for your configuration"
@@ -119,8 +119,8 @@ variable "private_endpoint" {
   type        = bool
   default     = true
 }
-variable "activity_tracker_instance_name" {
-  description = "Name of Activity Tracker Instance. If null it doesnt create activity tracker instance."
+variable "activity_tracker_instance" {
+  description = "GUID of Activity Tracker Instance. If null it doesnt create activity tracker instance."
   default     = null
   type        = string
 }
@@ -132,12 +132,13 @@ variable "custom_sg_rules" {
   type        = any // Refer README for type
   default     = []
 }
-
 variable "ip_ranges" {
-  description = "Ordered List of ip_ranges on which subnets has to be created."
+  description = "Ordered List of ip_ranges on which subnets has to be created. Conflicts with number_of_addresses argument"
   type        = list(string)
-  validation {
-    condition     = var.ip_ranges != [] && length(var.ip_ranges) == 3
-    error_message = "Length of ip_ranges should be 3. This modules supports creation of 3 multizone subnets."
-  }
+  default     = null
+}
+variable "number_of_addresses" {
+  description = "Number of IPV4 Addresses. Conflicts with ip_ranges argument"
+  type        = number
+  default     = 256
 }

--- a/examples/secure-roks-cluster/versions.tf
+++ b/examples/secure-roks-cluster/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     ibm = {
-      source = "IBM-Cloud/ibm"
+      source  = "IBM-Cloud/ibm"
+      version = ">=1.29.0"
     }
   }
 }


### PR DESCRIPTION
- The following three attributes are renamed and new attributes takes Id of instance but not name..
     - `activity_tracker_instance_name` ==> `activity_tracker_instance`
     - `logdna_name` ==> `logdna_instance`
     - `sysdig_name` ==> `sysdig_instance`  

- `kms_instance`, `kms_key`  takes Id of instance and Key but not name..
- Removed additional workerpool
- Default worker pool is created with 3 workers each, across 3 regions
- `ocp_version` ==> default of this variable is made to `null` from `4.6_openshift`, So that it takes latest ocp for creation
- Added `number_of_addresses` to subnet.. It default to `256`
- `ip_ranges`  argument is made optional
- Default `allow_all  outbound rule` is deleted before cluster creation
- Add security rules to default security group recommended by Brad
- Add  ip ranges of all subnets as outbound rules to default security group.. All these security group rules are added before cluster creation
- Provider version is restricted to 1.29.0