### PR TITLE
Updated secure-roks-cluster to remove deprecated modules and 

### DIFF
--- a/examples/secure-roks-cluster/iam.tf
+++ b/examples/secure-roks-cluster/iam.tf
@@ -1,17 +1,6 @@
-# module "roks_kms_authorisation_policy" {
-#   source              = "terraform-ibm-modules/iam/ibm//modules/service-authorization"
-#   version             = "1.2.2"
-#   count               = var.roks_kms_policy ? 0 : 1
-#   source_service_name = "containers-kubernetes"
-#   target_service_name = "kms"
-#   roles               = ["Reader"]
-# }
-
-# LMA
 resource "ibm_iam_authorization_policy" "kms_authorisation_policy" {
   count               = var.roks_kms_policy ? 0 : 1
   source_service_name = "containers-kubernetes"
-  # source_resource_instance_id = module.vpc_ocp_cluster.id
   target_service_name = "kms"
   roles               = ["Reader"]
 }

--- a/examples/secure-roks-cluster/iam.tf
+++ b/examples/secure-roks-cluster/iam.tf
@@ -11,7 +11,7 @@
 resource "ibm_iam_authorization_policy" "kms_authorisation_policy" {
   count                       = var.roks_kms_policy ? 0 : 1
   source_service_name         = "containers-kubernetes"
-  source_resource_instance_id = ibm_container_vpc_cluster.iks_cluster.id
+  # source_resource_instance_id = module.vpc_ocp_cluster.id
   target_service_name         = "kms"
   roles                       = ["Reader"]
 }

--- a/examples/secure-roks-cluster/iam.tf
+++ b/examples/secure-roks-cluster/iam.tf
@@ -1,8 +1,17 @@
-module "roks_kms_authorisation_policy" {
-  source              = "terraform-ibm-modules/iam/ibm//modules/service-authorization"
-  version             = "1.2.2"
-  count               = var.roks_kms_policy ? 0 : 1
-  source_service_name = "containers-kubernetes"
-  target_service_name = "kms"
-  roles               = ["Reader"]
+# module "roks_kms_authorisation_policy" {
+#   source              = "terraform-ibm-modules/iam/ibm//modules/service-authorization"
+#   version             = "1.2.2"
+#   count               = var.roks_kms_policy ? 0 : 1
+#   source_service_name = "containers-kubernetes"
+#   target_service_name = "kms"
+#   roles               = ["Reader"]
+# }
+
+# LMA
+resource "ibm_iam_authorization_policy" "kms_authorisation_policy" {
+  count                       = var.roks_kms_policy ? 0 : 1
+  source_service_name         = "containers-kubernetes"
+  source_resource_instance_id = ibm_container_vpc_cluster.iks_cluster.id
+  target_service_name         = "kms"
+  roles                       = ["Reader"]
 }

--- a/examples/secure-roks-cluster/iam.tf
+++ b/examples/secure-roks-cluster/iam.tf
@@ -9,9 +9,9 @@
 
 # LMA
 resource "ibm_iam_authorization_policy" "kms_authorisation_policy" {
-  count                       = var.roks_kms_policy ? 0 : 1
-  source_service_name         = "containers-kubernetes"
+  count               = var.roks_kms_policy ? 0 : 1
+  source_service_name = "containers-kubernetes"
   # source_resource_instance_id = module.vpc_ocp_cluster.id
-  target_service_name         = "kms"
-  roles                       = ["Reader"]
+  target_service_name = "kms"
+  roles               = ["Reader"]
 }

--- a/examples/secure-roks-cluster/kms.tf
+++ b/examples/secure-roks-cluster/kms.tf
@@ -1,18 +1,3 @@
-# module "kms" {
-#   count                = var.kms_instance == null && var.kms_key == null ? 1 : 0
-#   source               = "terraform-ibm-modules/kms/ibm//modules/key-protect"
-#   version              = "1.1.0"
-# is_kp_instance_exist = false
-# resource_group_id    = data.ibm_resource_group.resource_group.id
-# service_name         = "${var.resource_prefix}-kp"
-# location             = var.region
-# plan                 = "tiered-pricing"
-# tags                 = ["secure-roks", var.resource_prefix]
-#   key_name             = "${var.resource_prefix}-kp-key"
-#   standard_key_type    = var.standard_key_type
-# }
-
-# LMA
 resource "ibm_resource_instance" "kms" {
   count             = var.kms_instance == null && var.kms_key == null ? 1 : 0
   resource_group_id = data.ibm_resource_group.resource_group.id

--- a/examples/secure-roks-cluster/kms.tf
+++ b/examples/secure-roks-cluster/kms.tf
@@ -13,13 +13,14 @@
 # }
 
 # LMA
-resource "ibm_resource_instance" kms" {
+resource "ibm_resource_instance" "kms" {
+  count             = var.kms_instance == null && var.kms_key == null ? 1 : 0
   resource_group_id = data.ibm_resource_group.resource_group.id
   name              = "${var.resource_prefix}-kp"
   service           = "kms"
   plan              = "tiered-pricing"
   location          = var.region
-  tags                 = ["secure-roks", var.resource_prefix]
+  tags              = ["secure-roks", var.resource_prefix]
   service_endpoints = "private"
 }
 

--- a/examples/secure-roks-cluster/kms.tf
+++ b/examples/secure-roks-cluster/kms.tf
@@ -1,13 +1,30 @@
-module "kms" {
-  count                = var.kms_instance == null && var.kms_key == null ? 1 : 0
-  source               = "terraform-ibm-modules/kms/ibm//modules/key-protect"
-  version              = "1.1.0"
-  is_kp_instance_exist = false
-  resource_group_id    = data.ibm_resource_group.resource_group.id
-  service_name         = "${var.resource_prefix}-kp"
-  location             = var.region
-  plan                 = "tiered-pricing"
+# module "kms" {
+#   count                = var.kms_instance == null && var.kms_key == null ? 1 : 0
+#   source               = "terraform-ibm-modules/kms/ibm//modules/key-protect"
+#   version              = "1.1.0"
+  # is_kp_instance_exist = false
+  # resource_group_id    = data.ibm_resource_group.resource_group.id
+  # service_name         = "${var.resource_prefix}-kp"
+  # location             = var.region
+  # plan                 = "tiered-pricing"
+  # tags                 = ["secure-roks", var.resource_prefix]
+#   key_name             = "${var.resource_prefix}-kp-key"
+#   standard_key_type    = var.standard_key_type
+# }
+
+# LMA
+resource "ibm_resource_instance" kms" {
+  resource_group_id = data.ibm_resource_group.resource_group.id
+  name              = "${var.resource_prefix}-kp"
+  service           = "kms"
+  plan              = "tiered-pricing"
+  location          = var.region
   tags                 = ["secure-roks", var.resource_prefix]
-  key_name             = "${var.resource_prefix}-kp-key"
-  standard_key_type    = var.standard_key_type
+  service_endpoints = "private"
+}
+
+resource "ibm_kms_key" "key" {
+  instance_id  = ibm_resource_instance.kms.guid
+  key_name     = "${var.resource_prefix}-kp-key"
+  standard_key = var.standard_key_type
 }

--- a/examples/secure-roks-cluster/kms.tf
+++ b/examples/secure-roks-cluster/kms.tf
@@ -25,7 +25,7 @@ resource "ibm_resource_instance" "kms" {
 }
 
 resource "ibm_kms_key" "key" {
-  instance_id  = ibm_resource_instance.kms.guid
+  instance_id  = ibm_resource_instance.kms[0].guid
   key_name     = "${var.resource_prefix}-kp-key"
   standard_key = var.standard_key_type
 }

--- a/examples/secure-roks-cluster/kms.tf
+++ b/examples/secure-roks-cluster/kms.tf
@@ -2,12 +2,12 @@
 #   count                = var.kms_instance == null && var.kms_key == null ? 1 : 0
 #   source               = "terraform-ibm-modules/kms/ibm//modules/key-protect"
 #   version              = "1.1.0"
-  # is_kp_instance_exist = false
-  # resource_group_id    = data.ibm_resource_group.resource_group.id
-  # service_name         = "${var.resource_prefix}-kp"
-  # location             = var.region
-  # plan                 = "tiered-pricing"
-  # tags                 = ["secure-roks", var.resource_prefix]
+# is_kp_instance_exist = false
+# resource_group_id    = data.ibm_resource_group.resource_group.id
+# service_name         = "${var.resource_prefix}-kp"
+# location             = var.region
+# plan                 = "tiered-pricing"
+# tags                 = ["secure-roks", var.resource_prefix]
 #   key_name             = "${var.resource_prefix}-kp-key"
 #   standard_key_type    = var.standard_key_type
 # }

--- a/examples/secure-roks-cluster/locals.tf
+++ b/examples/secure-roks-cluster/locals.tf
@@ -15,7 +15,7 @@ locals {
     private_endpoint = true
     }] : [{
     #LMA instance_id      = module.kms[0].kms_instance_guid
-    instance_id      = ibm_resource_instance.kms[0].guid
+    instance_id = ibm_resource_instance.kms[0].guid
     #LMA crk_id           = module.kms[0].kms_key_id
     crk_id           = ibm_kms_key.key.id
     private_endpoint = true

--- a/examples/secure-roks-cluster/locals.tf
+++ b/examples/secure-roks-cluster/locals.tf
@@ -17,7 +17,7 @@ locals {
     #LMA instance_id      = module.kms[0].kms_instance_guid
     instance_id      = ibm_resource_instance.kms[0].guid
     #LMA crk_id           = module.kms[0].kms_key_id
-    crk_id           = ibm_kms_key.key[0].id
+    crk_id           = ibm_kms_key.key.id
     private_endpoint = true
   }]
   timeouts = [{

--- a/examples/secure-roks-cluster/locals.tf
+++ b/examples/secure-roks-cluster/locals.tf
@@ -14,8 +14,10 @@ locals {
     crk_id           = var.kms_key
     private_endpoint = true
     }] : [{
-    instance_id      = module.kms[0].kms_instance_guid
-    crk_id           = module.kms[0].kms_key_id
+    #LMA instance_id      = module.kms[0].kms_instance_guid
+    instance_id      = ibm_resource_instance.kms[0].guid
+    #LMA crk_id           = module.kms[0].kms_key_id
+    crk_id           = ibm_kms_key.key[0].id
     private_endpoint = true
   }]
   timeouts = [{

--- a/examples/secure-roks-cluster/locals.tf
+++ b/examples/secure-roks-cluster/locals.tf
@@ -14,9 +14,7 @@ locals {
     crk_id           = var.kms_key
     private_endpoint = true
     }] : [{
-    #LMA instance_id      = module.kms[0].kms_instance_guid
     instance_id = ibm_resource_instance.kms[0].guid
-    #LMA crk_id           = module.kms[0].kms_key_id
     crk_id           = ibm_kms_key.key.id
     private_endpoint = true
   }]

--- a/examples/secure-roks-cluster/logging.tf
+++ b/examples/secure-roks-cluster/logging.tf
@@ -13,6 +13,7 @@ module "logging_instance" {
   role              = "Manager"
   resource_key_tags = ["secure-roks", var.resource_prefix]
   parameters = {
-    default_receiver = true #enable for platform metrics
+    #LMA default_receiver = true #enable for platform metrics
+    default_receiver = false #enable for platform metrics
   }
 }

--- a/examples/secure-roks-cluster/monitoring.tf
+++ b/examples/secure-roks-cluster/monitoring.tf
@@ -13,7 +13,6 @@ module "monitoring_instance" {
   role              = "Manager"
   resource_key_tags = ["secure-roks", var.resource_prefix]
   parameters = {
-    #LMA default_receiver = true #enable for platform metrics
     default_receiver = false #enable for platform metrics
   }
 }

--- a/examples/secure-roks-cluster/monitoring.tf
+++ b/examples/secure-roks-cluster/monitoring.tf
@@ -13,6 +13,7 @@ module "monitoring_instance" {
   role              = "Manager"
   resource_key_tags = ["secure-roks", var.resource_prefix]
   parameters = {
-    default_receiver = true #enable for platform metrics
+    #LMA default_receiver = true #enable for platform metrics
+    default_receiver = false #enable for platform metrics
   }
 }

--- a/examples/secure-roks-cluster/testing.auto.tfvars
+++ b/examples/secure-roks-cluster/testing.auto.tfvars
@@ -6,3 +6,4 @@
 region           = "eu-de" # eu-de for Frankfurt MZR
 resource_group   = "secure"
 resource_prefix  = "secure"
+activity_tracker_instance = "5129f485-0195-4184-abe5-84716cb80e68"

--- a/examples/secure-roks-cluster/testing.auto.tfvars
+++ b/examples/secure-roks-cluster/testing.auto.tfvars
@@ -1,0 +1,8 @@
+##############################################################################
+## Global Variables
+##############################################################################
+
+# ibmcloud_api_key = ""
+region           = "eu-de" # eu-de for Frankfurt MZR
+resource_group   = "secure"
+resource_prefix  = "secure"

--- a/examples/secure-roks-cluster/testing.auto.tfvars
+++ b/examples/secure-roks-cluster/testing.auto.tfvars
@@ -3,7 +3,8 @@
 ##############################################################################
 
 # ibmcloud_api_key = ""
-region           = "eu-de" # eu-de for Frankfurt MZR
-resource_group   = "secure"
-resource_prefix  = "secure"
+region                    = "eu-de" # eu-de for Frankfurt MZR
+resource_group            = "secure"
+resource_prefix           = "secure"
+number_of_addresses       = 256
 activity_tracker_instance = "5129f485-0195-4184-abe5-84716cb80e68"

--- a/examples/secure-roks-cluster/testing.auto.tfvars
+++ b/examples/secure-roks-cluster/testing.auto.tfvars
@@ -7,4 +7,4 @@ region                    = "eu-de" # eu-de for Frankfurt MZR
 resource_group            = "secure"
 resource_prefix           = "secure"
 number_of_addresses       = 256
-activity_tracker_instance = "5129f485-0195-4184-abe5-84716cb80e68"
+# activity_tracker_instance = ""

--- a/examples/secure-roks-cluster/variables.tf
+++ b/examples/secure-roks-cluster/variables.tf
@@ -40,7 +40,7 @@ variable "flavor" {
 variable "ocp_version" {
   type        = string
   description = "Specify the Openshift version"
-  default     = "4.6_openshift"
+  default     = "4.13_openshift"
 }
 variable "ocp_entitlement" {
   type        = string


### PR DESCRIPTION
### Description

- removed module "roks_kms_authorisation_policy" because terraform-ibm-modules/iam/ibm//modules/service-authorization is archived
- remove module  "kms" because terraform-ibm-modules/kms/ibm//modules/key-protect is archived
- disables platform logging by default
- disabled platform monitoring by default
- added input file in tfvars
- added number for the subnet

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- When merging, use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
